### PR TITLE
Increase poker coverage

### DIFF
--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1,0 +1,126 @@
+import runpy
+import sys
+import pytest
+from click.testing import CliRunner
+
+import main
+
+
+def test_main_does_nothing():
+    assert main.main() is None
+
+
+def test_pg_invokes_print_game_results(monkeypatch):
+    called = {}
+
+    class FakePoker:
+        def __init__(self, ledger_folder_path, json_path):
+            called['init'] = (ledger_folder_path, json_path)
+            self.ledger_folder_path = ledger_folder_path
+            self.json_path = json_path
+
+        def print_game_results(self, csv_path):
+            called['csv'] = csv_path
+
+    monkeypatch.setattr(main, "Poker", FakePoker)
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["pg", "01_01"])
+    assert result.exit_code == 0
+    assert called == {
+        'init': ("ledgers", "data.json"),
+        'csv': "ledgers/ledger01_01.csv",
+    }
+
+
+def test_cb_invokes_print_combined_results(monkeypatch):
+    called = {}
+
+    class FakePoker:
+        def __init__(self, ledger_folder_path, json_path):
+            called['init'] = (ledger_folder_path, json_path)
+            self.ledger_folder_path = ledger_folder_path
+            self.json_path = json_path
+
+        def print_combined_results(self, paths):
+            called['paths'] = paths
+
+    monkeypatch.setattr(main, "Poker", FakePoker)
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["cb", "01_01", "01_02"])
+    assert result.exit_code == 0
+    assert called['init'] == ("ledgers", "data.json")
+    assert called['paths'] == [
+        "ledgers/ledger01_01.csv",
+        "ledgers/ledger01_02.csv",
+    ]
+
+
+def test_pgs_invokes_print_all_games(monkeypatch):
+    called = {}
+
+    class FakePoker:
+        def __init__(self, ledger_folder_path, json_path):
+            called['init'] = (ledger_folder_path, json_path)
+            self.ledger_folder_path = ledger_folder_path
+            self.json_path = json_path
+
+        def print_all_games(self):
+            called['called'] = True
+
+    monkeypatch.setattr(main, "Poker", FakePoker)
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["pgs"])
+    assert result.exit_code == 0
+    assert called == {'init': ("ledgers", "data.json"), 'called': True}
+
+
+def test_ag_invokes_add_poker_game(monkeypatch):
+    called = {}
+
+    class FakePoker:
+        def __init__(self, ledger_folder_path, json_path):
+            called['init'] = (ledger_folder_path, json_path)
+            self.ledger_folder_path = ledger_folder_path
+            self.json_path = json_path
+
+        def add_poker_game(self, path):
+            called['path'] = path
+
+    monkeypatch.setattr(main, "Poker", FakePoker)
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["ag", "01_03"])
+    assert result.exit_code == 0
+    assert called == {
+        'init': ("ledgers", "data.json"),
+        'path': "ledgers/ledger01_03.csv",
+    }
+
+
+def test_plg_invokes_print_last_games(monkeypatch):
+    called = {}
+
+    class FakePoker:
+        def __init__(self, ledger_folder_path, json_path):
+            called['init'] = (ledger_folder_path, json_path)
+            self.ledger_folder_path = ledger_folder_path
+            self.json_path = json_path
+
+        def print_last_games(self, nickname, n):
+            called['args'] = (nickname, n)
+
+    monkeypatch.setattr(main, "Poker", FakePoker)
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["plg", "Alice", "-n", "3"])
+    assert result.exit_code == 0
+    assert called == {
+        'init': ("ledgers", "data.json"),
+        'args': ("Alice", 3),
+    }
+
+
+def test_module_executes_main_and_cli(monkeypatch):
+    monkeypatch.syspath_prepend("backend")
+    monkeypatch.setattr(sys, "argv", ["main.py", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_path("backend/main.py", run_name="__main__")
+    assert exc.value.code == 0

--- a/backend/test_poker.py
+++ b/backend/test_poker.py
@@ -419,14 +419,12 @@ def test_combine_and_print_results(tem_dir_fixture3, capfd):
 
 def test_json_file_not_found():
     with pytest.raises(FileNotFoundError):
-        poker = Poker("testing/mock_ledgers", "fake_path.json")
-        poker.add_poker_game("testing/mock_ledgers/ledger01_01.csv")
+        Poker("testing/mock_ledgers", "fake_path.json")
 
 
 def test_ledger_folder_not_found():
     with pytest.raises(FileNotFoundError):
-        poker = Poker("fake_path", "testing/mock_jsons/mock1_data.json")
-        poker.add_poker_game("testing/mock_ledgers/ledger01_01.csv")
+        Poker("fake_path", "backend/testing/mock_jsons/mock1_data.json")
 
 
 def test_ledger_file_not_csv(tem_dir_fixture1):
@@ -446,6 +444,47 @@ def test_ledger_file_not_exist_print(tem_dir_fixture1):
     with pytest.raises(FileNotFoundError):
         poker.print_game_results("fake_ledger01_03.csv")
 
+
+# new tests covering edge cases in Poker.__init__ and _load_game_data
+
+def test_init_type_errors(tmp_path):
+    valid_dir = tmp_path / "ledgers"
+    valid_dir.mkdir()
+    valid_json = tmp_path / "data.json"
+    valid_json.write_text("{}")
+
+    with pytest.raises(TypeError):
+        Poker(123, str(valid_json))
+    with pytest.raises(TypeError):
+        Poker(str(valid_dir), 456)
+
+
+def test_init_value_errors(tmp_path):
+    valid_dir = tmp_path / "ledgers"
+    valid_dir.mkdir()
+    valid_json = tmp_path / "data.json"
+    valid_json.write_text("{}")
+
+    with pytest.raises(ValueError):
+        Poker("", str(valid_json))
+    with pytest.raises(ValueError):
+        Poker(str(valid_dir), "")
+
+
+def test_load_game_data_not_csv(tmp_path):
+    bad_file = tmp_path / "ledger01_01.txt"
+    bad_file.write_text("text")
+
+    with pytest.raises(ValueError):
+        Poker._load_game_data(str(bad_file))
+
+
+def test_load_game_data_bad_filename(tmp_path):
+    bad_file = tmp_path / "game01_01.csv"
+    bad_file.write_text("text")
+
+    with pytest.raises(ValueError):
+        Poker._load_game_data(str(bad_file))
 
 
 # def test_ledger_file_not_found(tem_dir_fixture1):


### PR DESCRIPTION
## Summary
- add missing tests for `Poker` edge cases
- fix failing paths in existing tests
- test `main` click CLI entry points

## Testing
- `pytest --cov=backend --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_68471bd31c00832b971f8d6a4f03b840